### PR TITLE
add more credit => usage rights parser

### DIFF
--- a/cleaners.js
+++ b/cleaners.js
@@ -17,7 +17,9 @@ export function cleanUndefinedKeys(o) {
 // Theseus returns an object with the uri as a property when the `data` object should be missing.
 // See: https://github.com/argo-rest/theseus/issues/21
 export function cleanTheseusBug(o) {
-    const keys = Object.keys(o);
-    if (keys.length === 1  && keys[0] === 'uri') { return; }
-    else { return o; }
+    if (o) {
+        const keys = Object.keys(o);
+        if (keys.length === 1  && keys[0] === 'uri') { return; }
+        else { return o; }
+    }
 }

--- a/commands.js
+++ b/commands.js
@@ -1,6 +1,6 @@
 import {cleanSource, cleanTheseusBug} from './cleaners';
 import {Agency} from './usage-rights';
-import {notPicdarDiffParams} from './params';
+import {costModelDiff} from './params';
 
 function command(query, params, processor) {
     return {query, params, processor};
@@ -56,7 +56,7 @@ export const patchMetadata = dataCommand(data => mapAll(image => {
 
 // TODO: We could probably batch these up
 export const aapCreditToUsageRights =
-    creditAgencyMapCommand("AAP", "AAP");
+    creditAgencyMapCommand('AAP', 'AAP');
 
 export const actionImagesCreditToUsageRights =
     creditAgencyMapCommand('Action Images', 'Action Images');
@@ -65,46 +65,64 @@ export const alamyImagesToCreditUsageRights =
     creditAgencyMapCommand('Alamy', 'Alamy');
 
 export const barcroftCreditToUsageRights =
-    creditAgencyMapCommand("Barcroft Media", "Barcroft Media");
+    creditAgencyMapCommand('Barcroft Media', 'Barcroft Media');
 
 export const apCreditToUsageRights =
-    creditAgencyMapCommand("AP", "AP");
+    creditAgencyMapCommand('AP', 'AP');
 
 export const assPressCreditToUsageRights =
-    creditAgencyMapCommand("Associated Press", "AP");
+    creditAgencyMapCommand('Associated Press', 'AP');
 
 export const corbisCreditToUsageRights =
-    creditAgencyMapCommand("Corbis", "Corbis");
+    creditAgencyMapCommand('Corbis', 'Corbis');
 
 export const epaCreditToUsageRights =
-    creditAgencyMapCommand("EPA", "EPA");
+    creditAgencyMapCommand('EPA', 'EPA');
 
 export const fairfaxUsageRights =
     creditAgencyMapCommand('Fairfax Media via Getty Images', 'Getty Images', 'Fairfax');
 
 export const paCreditToUsageRights =
-    creditAgencyMapCommand("PA", "PA");
+    creditAgencyMapCommand('PA', 'PA');
+
+export const paArchiveCreditToUsageRights =
+    creditAgencyMapCommand('PA Archive/Press Association Images', 'PA');
 
 export const reutersCreditUsageRights =
-    creditAgencyMapCommand('REUTERS', 'Reuters');
+    creditAgencyMapCommand('Reuters', 'Reuters');
 
 export const reutersUpperCreditUsageRights =
     creditAgencyMapCommand('REUTERS', 'Reuters');
 
+export const ronaldGrantArchiveUpperCreditUsageRights =
+    creditAgencyMapCommand('The Ronald Grant Archive', 'Ronald Grant Archive');
+
+export const ronaldGrantArchiveUpperCreditUsageRights =
+    creditAgencyMapCommand('THE RONALD GRANT ARCHIVE', 'Ronald Grant Archive');
+
 export const rexCreditToUsageRights =
-    creditAgencyMapCommand("Rex Features", "Rex Features");
+    creditAgencyMapCommand('Rex Features', 'Rex Features');
 
 // Getty Images
 export const gettyImagesUsageRights =
     creditAgencyMapCommand('Getty Images', 'Getty Images');
 
-export const afpMagicGettyImagesCreditToUsageRights =
+export const gettyAfpCreditToUsageRights =
+    creditAgencyMapCommand('AFP', 'Getty Images', 'AFP');
+
+export const gettyAfpGettyCreditToUsageRights =
     creditAgencyMapCommand('AFP/Getty Images', 'Getty Images', 'AFP');
 
-export const filmMagicGettyImagesCreditToUsageRights =
+export const gettyBfiGettyCreditToUsageRights =
+    creditAgencyMapCommand('BFI', 'Getty Images', 'BFI');
+
+export const gettyFilmMagicCreditToUsageRights =
     creditAgencyMapCommand('FilmMagic', 'Getty Images', 'FilmMagic');
 
-export const wireimageGettyImagesCreditToUsageRights =
+export const gettyHultonMagicCreditToUsageRights =
+    creditAgencyMapCommand('Hulton Getty', 'Getty Images', 'Hulton');
+
+export const gettyWireimageCreditToUsageRights =
     creditAgencyMapCommand('WireImage', 'Getty Images', 'WireImage');
 
 
@@ -137,16 +155,16 @@ function mapWithUserMetadata(mapperFunc) {
 function creditAgencyMapCommand(credit, supplier, suppliersCollection/*Option*/) {
     return presetCommand(
         `credit:"${credit}"`,
-        notPicdarDiffParams,
+        {free: true, costModelDiff: true},
         mapWithUserMetadata(image => {
             const source = suppliersCollection || cleanSource(image.data.metadata.source);
             // I'd prefer not to use ternaries but intellij borks.
-            const usageRights = (supplier === "Getty Images") ?
-                Agency("Getty Images", source) :
+            const usageRights = (supplier === 'Getty Images') ?
+                Agency('Getty Images', source) :
                 Agency(supplier);
 
             return image.data.userMetadata.data.usageRights.put({ data: usageRights }).then(() => {
-                console.log(`Set usage rights on ${image.data.id} with: Agency("${supplier}")`);
+                console.log(`Set usage rights on ${image.data.id} with: Agency('${supplier}')`);
             });
         })
     );

--- a/commands.js
+++ b/commands.js
@@ -178,7 +178,7 @@ function creditAgencyMapCommand(credit, supplier, suppliersCollection/*Option*/)
     return presetCommand(
         `credit:"${credit}"`,
         {free: true, costModelDiff: true, missingIdentifier: 'picdarUrn'},
-        mapWithUserMetadata(supplier, suppliersCollection)
+        setUsageRights(supplier, suppliersCollection)
     );
 }
 
@@ -188,12 +188,14 @@ function copyrightAgencyMapCommand(copyright, supplier, suppliersCollection/*Opt
     return presetCommand(
         `copyright:"${copyright}"`,
         {free: true, costModelDiff: true, hasIdentifier: 'picdarUrn'},
-        mapWithUserMetadata(supplier, suppliersCollection)
+        setUsageRights(supplier, suppliersCollection)
     );
 }
 
-function mapWithUserMetadata(supplier, suppliersCollection/*Option*/) {
-    return (image) => {
+function setUsageRights(supplier, suppliersCollection/*Option*/) {
+    return mapWithUserMetadata(image => {
+        console.log(image.data.metadata)
+
         const source = suppliersCollection || cleanSource(image.data.metadata.source);
         // I'd prefer not to use ternaries but intellij borks.
         const usageRights = (supplier === 'Getty Images') ?
@@ -203,7 +205,7 @@ function mapWithUserMetadata(supplier, suppliersCollection/*Option*/) {
         return image.data.userMetadata.data.usageRights.put({ data: usageRights }).then(() => {
             console.log(`Set usage rights on ${image.data.id} with: Agency('${supplier}')`);
         });
-    }
+    });
 }
 
 // TODO: set metadata or rights

--- a/commands.js
+++ b/commands.js
@@ -55,66 +55,67 @@ export const patchMetadata = dataCommand(data => mapAll(image => {
 
 // TODO: We could probably batch these up
 // Credit => Agency
-export const aapCreditToUsageRights =
+export const creditToUsageRightsAap =
     creditAgencyMapCommand('AAP', 'AAP');
 
-export const actionImagesCreditToUsageRights =
+export const creditToUsageRightsActionImages =
     creditAgencyMapCommand('Action Images', 'Action Images');
 
-export const alamyImagesToCreditUsageRights =
+export const creditToUsageRightsAlamyImages =
     creditAgencyMapCommand('Alamy', 'Alamy');
 
-export const barcroftCreditToUsageRights =
+export const creditToUsageRightsBarcroft =
     creditAgencyMapCommand('Barcroft Media', 'Barcroft Media');
 
-export const apCreditToUsageRights =
+export const creditToUsageRightsAp =
     creditAgencyMapCommand('AP', 'AP');
 
-export const assPressCreditToUsageRights =
+export const creditToUsageRightsAssPress =
     creditAgencyMapCommand('Associated Press', 'AP');
 
-export const corbisCreditToUsageRights =
+export const creditToUsageRightsCorbis =
     creditAgencyMapCommand('Corbis', 'Corbis');
 
-export const epaCreditToUsageRights =
+export const creditToUsageRightsEpa =
     creditAgencyMapCommand('EPA', 'EPA');
 
-export const fairfaxUsageRights =
+export const creditToUsageRightsFairfax =
     creditAgencyMapCommand('Fairfax Media via Getty Images', 'Getty Images', 'Fairfax');
 
-export const paCreditToUsageRights =
+export const creditToUsageRightspa =
     creditAgencyMapCommand('PA', 'PA');
 
-export const paArchiveCreditToUsageRights =
+export const creditToUsageRightspaArchive =
     creditAgencyMapCommand('PA Archive/Press Association Images', 'PA');
 
-export const reutersCreditUsageRights =
+export const creditToUsageRightsReuters =
     creditAgencyMapCommand('Reuters', 'Reuters');
 
-export const reutersUpperCreditUsageRights =
+export const creditToUsageRightsReutersUpper =
     creditAgencyMapCommand('REUTERS', 'Reuters');
 
-export const rexCreditToUsageRights =
+export const creditToUsageRightsRex =
     creditAgencyMapCommand('Rex Features', 'Rex Features');
 
 // Getty Images
-export const gettyImagesUsageRights =
+export const creditToUsageRightsImages =
     creditAgencyMapCommand('Getty Images', 'Getty Images');
 
-export const gettyAfpCreditToUsageRights =
+export const creditToUsageRightsAfp =
     creditAgencyMapCommand('AFP', 'Getty Images', 'AFP');
 
-export const gettyAfpGettyCreditToUsageRights =
+export const creditToUsageRightsAfpGetty =
     creditAgencyMapCommand('AFP/Getty Images', 'Getty Images', 'AFP');
 
-export const gettyBfiGettyCreditToUsageRights =
+export const creditToUsageRightsBfiGetty =
     creditAgencyMapCommand('BFI', 'Getty Images', 'BFI');
 
-export const gettyFilmMagicCreditToUsageRights =
+export const creditToUsageRightsFilmMagic =
     creditAgencyMapCommand('FilmMagic', 'Getty Images', 'FilmMagic');
 
-export const gettyWireimageCreditToUsageRights =
+export const creditToUsageRightsgettyWireImage =
     creditAgencyMapCommand('WireImage', 'Getty Images', 'WireImage');
+
 
 // Copyright => Agency
 export const copyrightToUsageRightsReuters =
@@ -172,21 +173,21 @@ function mapWithUserMetadata(mapperFunc) {
 }
 
 // This is used to set the usage rights on images that have had their credit set in the Grid
-// making them free to use
+// making them free to use - only run on non-picdar images.
 function creditAgencyMapCommand(credit, supplier, suppliersCollection/*Option*/) {
     return presetCommand(
         `credit:"${credit}"`,
-        {free: true, costModelDiff: true},
+        {free: true, costModelDiff: true, missingIdentifier: 'picdarUrn'},
         mapWithUserMetadata(supplier, suppliersCollection)
     );
 }
 
 // This is used to set the usage rights on images that have had their copyright set in the Picdar to
-// making them free to use
+// making them free to use. Only run on Picdar images.
 function copyrightAgencyMapCommand(copyright, supplier, suppliersCollection/*Option*/) {
     return presetCommand(
         `copyright:"${copyright}"`,
-        {free: true, costModelDiff: true},
+        {free: true, costModelDiff: true, hasIdentifier: 'picdarUrn'},
         mapWithUserMetadata(supplier, suppliersCollection)
     );
 }

--- a/commands.js
+++ b/commands.js
@@ -82,10 +82,10 @@ export const creditToUsageRightsEpa =
 export const creditToUsageRightsFairfax =
     creditAgencyMapCommand('Fairfax Media via Getty Images', 'Getty Images', 'Fairfax');
 
-export const creditToUsageRightspa =
+export const creditToUsageRightsPa =
     creditAgencyMapCommand('PA', 'PA');
 
-export const creditToUsageRightspaArchive =
+export const creditToUsageRightsPaArchive =
     creditAgencyMapCommand('PA Archive/Press Association Images', 'PA');
 
 export const creditToUsageRightsReuters =
@@ -98,7 +98,7 @@ export const creditToUsageRightsRex =
     creditAgencyMapCommand('Rex Features', 'Rex Features');
 
 // Getty Images
-export const creditToUsageRightsImages =
+export const creditToUsageRightsGetty =
     creditAgencyMapCommand('Getty Images', 'Getty Images');
 
 export const creditToUsageRightsAfp =
@@ -113,7 +113,7 @@ export const creditToUsageRightsBfiGetty =
 export const creditToUsageRightsFilmMagic =
     creditAgencyMapCommand('FilmMagic', 'Getty Images', 'FilmMagic');
 
-export const creditToUsageRightsgettyWireImage =
+export const creditToUsageRightsWireImage =
     creditAgencyMapCommand('WireImage', 'Getty Images', 'WireImage');
 
 
@@ -125,10 +125,16 @@ export const copyrightToUsageRightsRonaldGrantArchive =
     copyrightAgencyMapCommand('THE RONALD GRANT ARCHIVE', 'Ronald Grant Archive');
 
 export const copyrightToUsageRightsRonaldGrant =
-    copyrightAgencyMapCommand('RONALD GRANT', 'Reuters');
+    copyrightAgencyMapCommand('RONALD GRANT', 'Ronald Grant Archive');
 
 export const copyrightToUsageRightsPa =
     copyrightAgencyMapCommand('PA Archive/Press Association Images', 'PA');
+
+export const copyrightToUsageRightsAp =
+    copyrightAgencyMapCommand('AP', 'AP');
+
+export const copyrightToUsageRightsGetty =
+    copyrightAgencyMapCommand('Getty Images', 'Getty Images');
 
 export const copyrightToUsageRightsGettyAfp =
     copyrightAgencyMapCommand('AFP', 'Getty Images', 'AFP');
@@ -159,7 +165,7 @@ function mapWithUserMetadata(mapperFunc) {
         console.log(`Total results: ${results.total}`);
         const mapped = results.data.map(image => {
             const usageRightsOverrides = cleanTheseusBug(image.data.userMetadata.data.usageRights.data);
-            const metadataOverrides = cleanTheseusBug(image.data.userMetadata.data.metadata.data)
+            const metadataOverrides = cleanTheseusBug(image.data.userMetadata.data.metadata.data);
             // we are only looking to run this function on images that have metadata overrides
             // and no usageRights already set
             if (metadataOverrides && !usageRightsOverrides) {
@@ -194,8 +200,6 @@ function copyrightAgencyMapCommand(copyright, supplier, suppliersCollection/*Opt
 
 function setUsageRights(supplier, suppliersCollection/*Option*/) {
     return mapWithUserMetadata(image => {
-        console.log(image.data.metadata)
-
         const source = suppliersCollection || cleanSource(image.data.metadata.source);
         // I'd prefer not to use ternaries but intellij borks.
         const usageRights = (supplier === 'Getty Images') ?
@@ -203,7 +207,7 @@ function setUsageRights(supplier, suppliersCollection/*Option*/) {
             Agency(supplier);
 
         return image.data.userMetadata.data.usageRights.put({ data: usageRights }).then(() => {
-            console.log(`Set usage rights on ${image.data.id} with: Agency('${supplier}')`);
+            console.log(`Set usage rights on ${image.data.id} with: Agency('${supplier}', '${suppliersCollection}')`);
         });
     });
 }

--- a/params.js
+++ b/params.js
@@ -1,2 +1,0 @@
-export const notPicdarDiffParams =
-    {free: true, costModelDiff: true, missingIdentifier: 'picdarUrn'};


### PR DESCRIPTION
To match [this](https://github.com/guardian/grid/pull/1220/files#diff-71148a456ec805e1c913907801872edcR59)

I've also removed that it only checks non-picdar versions - this will apply to all.
I don't suppose it matters if the overrides come from the Picdar exporter or here.
